### PR TITLE
Updated curator version to 3.5.1 and provided crude support for ssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM gliderlabs/alpine:3.2
+FROM gliderlabs/alpine:latest
 
-ENV CURATOR_VERSION 3.2.0
+ENV CURATOR_VERSION 3.5.1
 ENV ELASTICSEARCH_PORT 9200
 
 RUN apk --update add python py-pip bash && pip install elasticsearch-curator==$CURATOR_VERSION

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The list of tasks currently are:
 
 ## Configuration
 
-`ELASTICSEARCH_HOST` - The hostname or IP address of an elasticsearch cluster.
+`ELASTICSEARCH_HOST` - The hostname or IP address of an elasticsearch cluster. (Required)
 
-`MAX_INDEX_AGE` - The maximum age (in days) a logstash index can be until it is deleted.
+`MAX_INDEX_AGE` - The maximum age (in days) a logstash index can be until it is deleted. (Required)
+
+`ELASTICSEARCH_PORT` - Specify the instance port. If not set default is 9200.
+
+`USE_SSL` - set to true and specify the correct port with `ELASTICSEARCH_PORT`

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,4 +7,5 @@ if [ -z "$ELASTICSEARCH_HOST" ]; then
   exit 1
 fi
 
+echo "contatiner started"
 exec "$@"

--- a/tasks/optimize-indices.sh
+++ b/tasks/optimize-indices.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
-
-curator --host $ELASTICSEARCH_HOST --port $ELASTICSEARCH_PORT optimize --max_num_segments 1 indices --prefix logstash --older-than 1 --time-unit days --timestring '%Y.%m.%d'
+if [ -n "$USE_SSL" ]; then
+    curator --host $ELASTICSEARCH_HOST --port $ELASTICSEARCH_PORT --use_ssl optimize --max_num_segments 1 indices --prefix logstash --older-than 1 --time-unit days --timestring '%Y.%m.%d'
+else
+    curator --host $ELASTICSEARCH_HOST --port $ELASTICSEARCH_PORT optimize --max_num_segments 1 indices --prefix logstash --older-than 1 --time-unit days --timestring '%Y.%m.%d'
+fi

--- a/tasks/purge-old-indices.sh
+++ b/tasks/purge-old-indices.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-if [ -n "$MAX_INDEX_AGE" ]; then
+if [ -n "$MAX_INDEX_AGE" ] && [ -z "$USE_SSL" ]; then
   /usr/bin/curator --host $ELASTICSEARCH_HOST --port $ELASTICSEARCH_PORT delete indices --older-than $MAX_INDEX_AGE --time-unit days --prefix logstash  --timestring '%Y.%m.%d'
+elif [ -n "$MAX_INDEX_AGE" ] && [ -n "$USE_SSL" ]; then
+  /usr/bin/curator --host $ELASTICSEARCH_HOST --port $ELASTICSEARCH_PORT --use_ssl delete indices --older-than $MAX_INDEX_AGE --time-unit days --prefix logstash  --timestring '%Y.%m.%d'
 else
   echo "Skip purging old indices. MAX_INDEX_AGE is not set."
 fi


### PR DESCRIPTION
SSL support for the current tasks.

This was done so I could use this docker service with AWS ES.

It might also be good to update it to the most recent version 4.x and make changes to suit since my AWS use case is very specific.
